### PR TITLE
Allow classes with memoized methods to be reloaded

### DIFF
--- a/test/dummy_class.rb
+++ b/test/dummy_class.rb
@@ -1,0 +1,12 @@
+# A class in its own file that we can load repeatedly
+class Dummy
+  extend Memoist
+
+  def increment
+    @value ||= 0
+    @value += 1
+  end
+
+  memoize :increment
+
+end

--- a/test/dummy_module.rb
+++ b/test/dummy_module.rb
@@ -1,0 +1,12 @@
+# A module in its own file that we can load repeatedly
+module DummyModule
+  extend Memoist
+
+  def module_increment
+    @mod_value ||= 0
+    @mod_value += 1
+  end
+
+  memoize :module_increment
+
+end

--- a/test/dummy_subclass.rb
+++ b/test/dummy_subclass.rb
@@ -1,0 +1,12 @@
+# A subclass in its own file that we can load repeatedly
+class DummySubclass < Dummy
+  extend Memoist
+
+  def sub_increment
+    @sub_value ||= 0
+    @sub_value += 1
+  end
+
+  memoize :sub_increment
+
+end


### PR DESCRIPTION
When developing in Rails it is common to keep an irb console open and rely on autoloading to refresh files as you edit them. However, I found that classes with memoized methods couldn't be reloaded at all due to "already memoized" errors and required restarting irb to get the updates.

Here is what happens:
1. A file with a class is loaded
   1. The class is defined
   2. Memoist is extended
   3. Memoized versions of methods are created
2. The same file is loaded again (e.g. via 'load' or some auto-reload mechanism as in Rails)
   1. The class is defined (note: this is now modifying the originally loaded definition)
   2. Memoist is extended
   3. The first "memoize" raises an "already memoized" error because the original still exists.

This proposed fix is to detect when Memoist is extended and remove previously memoized methods defined in the current class. Then the class can continue loading as normal and re-memoize methods as desired.
