### PR TITLE
Enable to set value to memoized method externally

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -81,6 +81,11 @@ module Memoist
         remove_instance_variable(ivar) if instance_variable_defined?(ivar)
       end
     end
+
+    def set_cache(method_name, value)
+      memoized_ivar = Memoist.memoized_ivar_for(method_name)
+      instance_variable_set(memoized_ivar, value)
+    end
   end
 
   def memoize(*method_names)

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -331,4 +331,11 @@ class MemoistTest < Test::Unit::TestCase
     assert_equal 1, person.is_developer_calls
   end
 
+  def test_memoization_with_custom_value
+    person = Person.new
+    person.set_cache(:is_developer?, "No")
+    assert_equal "No", person.send(:is_developer?)
+    assert_equal 0, person.is_developer_calls
+  end
+
 end


### PR DESCRIPTION
Thanks for creating and maintaining this gem. :) We're currently evaluating to use this gem in our production code.

This pull request changes API. Namely it adds a new instance method called `set_cache`. This method can be used to set a memoized method to value from external.

In our code base, we need to assign the same value to huge number of objects at once in the batch processing for further manipulation of these objects.

In such a case, we would like to reuse the same object computed once at the entry point before the hot loop instead of repeatedly calling the memoized method for each and every objects.

So we'd like to have an official API to do that.
