### PR TITLE
Make memoize return a :symbol

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -193,6 +193,8 @@ module Memoist
         end
       end
     end
+    # return a chainable method_name symbol if we can
+    method_names.length == 1 ? method_names.first : method_names
   end
 
   class AlreadyMemoizedError < RuntimeError; end

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -312,6 +312,15 @@ class MemoistTest < Minitest::Unit::TestCase
     assert_equal 1, student.name_calls
   end
 
+  def test_memoization_is_chainable
+    klass = Class.new do
+      def foo; "bar"; end
+    end
+    klass.extend Memoist
+    chainable = klass.memoize :foo
+    assert_equal :foo, chainable
+  end
+
   def test_protected_method_memoization
     person = Person.new
 


### PR DESCRIPTION
should make it chainable.

``` ruby
private memoize def something
  "nothing"
end
```
