### PR TITLE
Call abs on arity when extracting reload

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -31,7 +31,7 @@ module Memoist
   end
 
   def self.extract_reload!(method, args)
-    if args.length == method.arity + 1 && (args.last == true || args.last == :reload)
+    if args.length == method.arity.abs + 1 && (args.last == true || args.last == :reload)
       reload = args.pop
     end
     reload

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -70,6 +70,26 @@ class MemoistTest < Minitest::Unit::TestCase
 
     memoize :name, :age
 
+    def sleep(hours = 8)
+      @counter.call(:sleep)
+      hours
+    end
+    memoize :sleep
+
+    def sleep_calls
+      @counter.count(:sleep)
+    end
+
+    def update_attributes(options = {})
+      @counter.call(:update_attributes)
+      true
+    end
+    memoize :update_attributes
+
+    def update_attributes_calls
+      @counter.count(:update_attributes)
+    end
+
     protected
 
     def memoize_protected_test
@@ -165,6 +185,28 @@ class MemoistTest < Minitest::Unit::TestCase
 
     3.times { assert_equal "Josh", @person.name }
     assert_equal 1, @person.name_calls
+  end
+
+  def test_memoize_with_optional_arguments
+    assert_equal 4, @person.sleep(4)
+    assert_equal 1, @person.sleep_calls
+
+    3.times { assert_equal 4, @person.sleep(4) }
+    assert_equal 1, @person.sleep_calls
+
+    3.times { assert_equal 4, @person.sleep(4, :reload) }
+    assert_equal 4, @person.sleep_calls
+  end
+
+  def test_memoize_with_options_hash
+    assert_equal true, @person.update_attributes(:age => 21, :name => 'James')
+    assert_equal 1, @person.update_attributes_calls
+
+    3.times { assert_equal true, @person.update_attributes(:age => 21, :name => 'James') }
+    assert_equal 1, @person.update_attributes_calls
+
+    3.times { assert_equal true, @person.update_attributes({:age => 21, :name => 'James'}, :reload) }
+    assert_equal 4, @person.update_attributes_calls
   end
 
   def test_memoization_with_punctuation


### PR DESCRIPTION
Fixes #23 
- Optional arguments in the method signature cause arity to be a
  negative number. Call abs on the method arity to fix optional values not
  working and throwing something like:
  
  ArgumentError:   wrong number of arguments (3 for 2)
