### PR TITLE
Fix forking link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Everyone who contributed to it in the rails repository.
 Contributing
 ============
 
-1. Fork it ( http://github.com/<my-github-username>/memoist/fork )
+1. Fork it ( http://github.com/*my-github-username*/memoist/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
the `<` and `>` make the forking link render all wrong, since they cause the text between them to be interpreted as HTML.