### PR TITLE
Faster memoist with less object allocations

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -60,15 +60,7 @@ module Memoist
     end
 
     def prime_cache(*method_names)
-      if method_names.empty?
-        prefix = Memoist.unmemoized_prefix+"_"
-        method_names = methods.collect do |method_name|
-          if method_name.to_s.start_with?(prefix)
-            method_name[prefix.length..-1]
-          end
-        end.compact
-      end
-
+      method_names = self.class.memoized_methods if method_names.empty?
       method_names.each do |method_name|
         if method(Memoist.unmemoized_method_for(method_name)).arity == 0
           __send__(method_name)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -23,7 +23,16 @@ module Memoist
   end
 
   def self.escape_punctuation(string)
-    string.sub(/\?\Z/, '_query'.freeze).sub(/!\Z/, '_bang'.freeze)
+    return string unless string.end_with?('?'.freeze, '!'.freeze)
+
+    string = string.dup
+
+    # A String can't end in both ? and !
+    if string.sub!(/\?\Z/, '_query'.freeze)
+    else
+      string.sub!(/!\Z/, '_bang'.freeze)
+    end
+    string
   end
 
   def self.memoist_eval(klass, *args, &block)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -3,7 +3,7 @@ require 'memoist/core_ext/singleton_class'
 module Memoist
 
   def self.memoized_ivar_for(method_name, identifier=nil)
-    ["@#{memoized_prefix(identifier)}", escape_punctuation(method_name.to_s)].join("_")
+    "@#{memoized_prefix(identifier)}_#{escape_punctuation(method_name.to_s)}"
   end
 
   def self.unmemoized_method_for(method_name, identifier=nil)
@@ -11,7 +11,7 @@ module Memoist
   end
 
   def self.memoized_prefix(identifier=nil)
-    ["_memoized", identifier].compact.join("_")
+    ["_memoized".freeze, identifier].compact.join("_".freeze)
   end
 
   def self.unmemoized_prefix(identifier=nil)
@@ -19,7 +19,7 @@ module Memoist
   end
 
   def self.escape_punctuation(string)
-    string.sub(/\?\Z/, '_query').sub(/!\Z/, '_bang')
+    string.sub(/\?\Z/, '_query'.freeze).sub(/!\Z/, '_bang'.freeze)
   end
 
   def self.memoist_eval(klass, *args, &block)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -11,7 +11,11 @@ module Memoist
   end
 
   def self.memoized_prefix(identifier=nil)
-    ["_memoized".freeze, identifier].compact.join("_".freeze)
+    if identifier
+      "_memoized_#{identifier}"
+    else
+      "_memoized".freeze
+    end
   end
 
   def self.unmemoized_prefix(identifier=nil)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -7,7 +7,7 @@ module Memoist
   end
 
   def self.unmemoized_method_for(method_name, identifier=nil)
-    [unmemoized_prefix(identifier), method_name].join("_").to_sym
+    "#{unmemoized_prefix(identifier)}_#{method_name}".to_sym
   end
 
   def self.memoized_prefix(identifier=nil)
@@ -19,7 +19,11 @@ module Memoist
   end
 
   def self.unmemoized_prefix(identifier=nil)
-    ["_unmemoized", identifier].compact.join("_")
+    if identifier
+      "_unmemoized_#{identifier}"
+    else
+      "_unmemoized".freeze
+    end
   end
 
   def self.escape_punctuation(string)

--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -76,9 +76,7 @@ module Memoist
     end
 
     def flush_cache(*method_names)
-      if method_names.empty?
-        method_names = self.class.memoized_methods
-      end
+      method_names = self.class.memoized_methods if method_names.empty?
 
       method_names.each do |method_name|
         ivar = Memoist.memoized_ivar_for(method_name)


### PR DESCRIPTION
#### Summary:
* Track the memoized methods for faster memoize_all/unmemoize_all so we don't have to use introspection methods such as `methods` for information we can "remember"
* Use String interpolation over `Array#join` (less strings, arrays and array operations)
* Use a conditional instead of `Array#compact` (less arrays and array operations)
* Change `escape_punctuation` to be much faster and less allocations for the more common case: methods not ending with `!` or `?`

See each commit for more information and diagnostic scripts to track allocations/time savings.

For a class with 40 memoized methods where we prime and flush the cache 1,000 times.

#### prime_cache/flush_cache with a list of methods:
##### Before:
`ruby prime_flush_cache.rb  0.33s user 0.04s system 98% cpu 0.372 total`

##### After:
`ruby prime_flush_cache.rb  0.19s user 0.03s system 97% cpu 0.221 total`

#### prime_cache/flush_cache with no args:
##### Before:
`ruby prime_flush_cache.rb  0.62s user 0.03s system 99% cpu 0.654 total`

#### After:
`ruby prime_flush_cache.rb  0.21s user 0.03s system 98% cpu 0.243 total`

Additionally, for the same scenario, the object allocations drop:
**58% less objects** for a list of methods pass to prime/flush cache (781025 => 328000 )
**78% less objects** for no args to prime/flush cache (1536562 => 336000)

```ruby
require './lib/memoist'
require 'set'

$methods = Set.new
class Person
  extend Memoist
  1.upto(20) do |n|
    method = define_method("test_#{n}".to_sym) {}
    memoize(method)
    $methods.add(method)
  end

  1.upto(20) do |n|
    method = define_method("test_#{n}?".to_sym) {}
    memoize(method)
    $methods.add(method)
  end
end

p = Person.new
1_000.times do
  p.prime_cache
  p.flush_cache
end
```