### PR TITLE
implement BlocksNotSupported exception

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -1,4 +1,5 @@
 require 'memoist/core_ext/singleton_class'
+require 'memoist/blocks_not_supported'
 
 module Memoist
 
@@ -114,6 +115,8 @@ module Memoist
       identifier = method_names.pop[:identifier]
     end
 
+    memoize_caller = caller(1..1).first
+
     Memoist.memoist_eval(self) do
       def self.memoized_methods
         @_memoized_methods ||= []
@@ -157,7 +160,13 @@ module Memoist
           # end
 
           module_eval <<-EOS, __FILE__, __LINE__ + 1
-            def #{method_name}(reload = false)
+            def #{method_name}(reload = false, &block)
+              if block
+                raise Memoist::BlocksNotSupported,
+                      "Calls with block is not alowed for memoized method #{method_name}\n" \
+                      "memoist called at #{memoize_caller}"
+              end
+
               skip_cache = reload || !instance_variable_defined?("#{memoized_ivar}")
               set_cache = skip_cache && !frozen?
 
@@ -199,7 +208,13 @@ module Memoist
           # end
 
           module_eval <<-EOS, __FILE__, __LINE__ + 1
-            def #{method_name}(*args)
+            def #{method_name}(*args, &block)
+              if block
+                raise Memoist::BlocksNotSupported,
+                      "Calls with block is not alowed for memoized method #{method_name}\n" \
+                      "memoist called at #{memoize_caller}"
+              end
+
               reload = Memoist.extract_reload!(method(#{unmemoized_method.inspect}), args)
 
               skip_cache = reload || !(instance_variable_defined?(#{memoized_ivar.inspect}) && #{memoized_ivar} && #{memoized_ivar}.has_key?(args))

--- a/lib/memoist/blocks_not_supported.rb
+++ b/lib/memoist/blocks_not_supported.rb
@@ -1,0 +1,4 @@
+module Memoist
+  # Memoist does not support calls with block to cached method_names
+  BlocksNotSupported = Class.new(StandardError)
+end

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -461,4 +461,20 @@ class MemoistTest < Minitest::Test
     assert_equal 1, person.is_developer_calls
   end
 
+  def test_blocks_supported
+    person = Person.new
+
+    assert_raises(Memoist::BlocksNotSupported) { person.name { :block } }
+    assert_raises(Memoist::BlocksNotSupported) { person.update('smth') { :block } }
+  end
+
+  def test_block_contains_proper_caller
+    person = Person.new
+
+    begin
+      person.name { :block }
+    rescue Memoist::BlocksNotSupported => e
+      assert(e.message =~ /memoist_test.rb:\d+/, "message should contain caller of memoize")
+    end
+  end
 end


### PR DESCRIPTION
When somebody calls memoized method with block, an informative error would be raised

closes https://github.com/matthewrudy/memoist/issues/39