### PR TITLE
Fix tests for Ruby < 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ rvm:
   - jruby-19mode
   - jruby-9.1.5.0
   - jruby-head
+
+before_install:
+  - gem install bundler --no-document -v '~> 1.13'
+before_script:
+  - unset JRUBY_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+  - ruby-head
   - jruby-18mode
   - jruby-19mode
-  - rbx-2
-  - ruby-head
+  - jruby-9.1.5.0
   - jruby-head
-  - ree

--- a/memoist.gemspec
+++ b/memoist.gemspec
@@ -34,6 +34,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
+  if RUBY_VERSION < '1.9.3'
+    spec.add_development_dependency "rake", "~> 10.4"
+  else
+    spec.add_development_dependency "rake"
+  end
   spec.add_development_dependency "minitest", "~> 5.5.1"
 end


### PR DESCRIPTION
Rake removed support for Ruby < 1.9.3 last year
Match this with our rake requirement.
https://github.com/ruby/rake/pull/86