### PR TITLE
Fix undefined `memoized_methods` error raised when a parent class has not call `memoize`

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -4,6 +4,16 @@ require 'memoist/core_ext/singleton_class'
 
 module Memoist
 
+  def self.extended(extender)
+    Memoist.memoist_eval(extender) do
+      unless singleton_class.method_defined?(:memoized_methods)
+        def self.memoized_methods
+          @_memoized_methods ||= []
+        end
+      end
+    end
+  end
+
   def self.memoized_ivar_for(method_name, identifier=nil)
     "@#{memoized_prefix(identifier)}_#{escape_punctuation(method_name)}"
   end
@@ -114,14 +124,6 @@ module Memoist
   def memoize(*method_names)
     if method_names.last.is_a?(Hash)
       identifier = method_names.pop[:identifier]
-    end
-
-    Memoist.memoist_eval(self) do
-      unless singleton_class.method_defined?(:memoized_methods)
-        def self.memoized_methods
-          @_memoized_methods ||= []
-        end
-      end
     end
 
     method_names.each do |method_name|

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -181,6 +181,33 @@ class MemoistTest < Minitest::Test
     memoize :counter
   end
 
+  class Abb
+    extend Memoist
+
+    def run(*args)
+      flush_cache if respond_to?(:flush_cache)
+      execute
+    end
+
+    def execute
+      some_method
+    end
+
+    def some_method
+      # Override this
+    end
+  end
+
+  class Bbb < Abb
+
+    def some_method
+      :foo
+    end
+    memoize :some_method
+  end
+
+
+
   def setup
     @person = Person.new
     @calculator = Calculator.new
@@ -254,6 +281,13 @@ class MemoistTest < Minitest::Test
     assert_equal false, @calculator.instance_variable_defined?(:@_memoized_counter)
 
     assert_equal 2, @calculator.counter
+  end
+
+  def test_flush_cache_in_child_class
+    x = Bbb.new
+
+    # This should not throw error
+    x.run
   end
 
   def test_unmemoize_all


### PR DESCRIPTION
Fixes #51 

The method `memoized_methods` is only defined when `memoize` method is called
Thus `memoized_methods` method is absent in any class that contains no method call to `memoize`

So this PR just define the method on module extend