### PR TITLE
Make Memoist.escape_punctuation compatible with MRI 2.7

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -38,9 +38,11 @@ module Memoist
   end
 
   def self.escape_punctuation(string)
-    string = string.is_a?(String) ? string.dup : string.to_s
+    string = string.to_s
 
     return string unless string.end_with?('?'.freeze, '!'.freeze)
+
+    string = string.dup if string.frozen?
 
     # A String can't end in both ? and !
     if string.sub!(/\?\Z/, '_query'.freeze)


### PR DESCRIPTION
In https://bugs.ruby-lang.org/issues/16150 MRI merge an experimental feature that makes `Symbol#to_s` return a frozen string.

So unless that experiment is reverted before release, `escape_punctuation` need to handle `string.to_s` being potentially frozen.

@matthewrudy 