### PR TITLE
Get not frozen string in Ruby 2.7

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -38,7 +38,7 @@ module Memoist
   end
 
   def self.escape_punctuation(string)
-    string = string.is_a?(String) ? string.dup : string.to_s
+    string = string.is_a?(String) ? string.dup : string.to_s.dup
 
     return string unless string.end_with?('?'.freeze, '!'.freeze)
 


### PR DESCRIPTION
`Symbol#to_s` always return a frozen String object from https://bugs.ruby-lang.org/issues/16150

```shell
$ ruby -v
ruby 2.7.0preview2 (2019-10-22 master 02aadf1032) [x86_64-linux]

$ bundle exec rake test
/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/bin/ruby -w -I"lib:test" -I"/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib" "/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb" "test/memoist_test.rb"
Traceback (most recent call last):
        12: from /home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb:5:in `<main>'
        11: from /home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb:5:in `select'
        10: from /home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb:17:in `block in <main>'
         9: from /home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb:17:in `require'
         8: from /home/unasuke/src/github.com/matthewrudy/memoist/test/memoist_test.rb:4:in `<top (required)>'
         7: from /home/unasuke/src/github.com/matthewrudy/memoist/test/memoist_test.rb:20:in `<class:MemoistTest>'
         6: from /home/unasuke/src/github.com/matthewrudy/memoist/test/memoist_test.rb:56:in `<class:Person>'
         5: from /home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:127:in `memoize'
         4: from /home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:127:in `each'
         3: from /home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:129:in `block in memoize'
         2: from /home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:17:in `memoized_ivar_for'
         1: from /home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:46:in `escape_punctuation'
/home/unasuke/src/github.com/matthewrudy/memoist/lib/memoist.rb:46:in `sub!': can't modify frozen String: "name?" (FrozenError)
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" -I"/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib" "/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/lib/ruby/gems/2.7.0/gems/rake-13.0.0/lib/rake/rake_test_loader.rb" "test/memoist_test.rb" ]
/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/bin/bundle:23:in `load'
/home/unasuke/.anyenv/envs/rbenv/versions/2.7.0-preview2/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```