### PR TITLE
Remove ruby 1.9.2 from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.10


### PR DESCRIPTION
- RVM not support 1.9.2 with `--binary` flag
    - 	https://travis-ci.org/matthewrudy/memoist/jobs/606960866
- Minor version is duplicated with 1.9.3

```shell
$ docker run -it --rm buildpack-deps:buster bash
root@66cac41f18c4:/# curl -sSL https://get.rvm.io | bash -s stable
# ...snip...
root@66cac41f18c4:/# source /etc/profile.d/rvm.sh
root@66cac41f18c4:/# rvm use 1.9.2 --install --binary --fuzzy
Required ruby-1.9.2 is not installed - installing.
Searching for binary rubies, this might take some time.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm ruby-1.9.2 do rvm gemset create ' first, or append '--create'.
```