### PR TITLE
Fix regression introduced by frozen symbol fix

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -38,11 +38,9 @@ module Memoist
   end
 
   def self.escape_punctuation(string)
-    string = string.to_s
+    string = string.is_a?(String) ? string.dup : string.to_s.dup
 
     return string unless string.end_with?('?'.freeze, '!'.freeze)
-
-    string = string.dup if string.frozen?
 
     # A String can't end in both ? and !
     if string.sub!(/\?\Z/, '_query'.freeze)

--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -67,6 +67,12 @@ class MemoistTest < Minitest::Test
 
     memoize :name, :age
 
+    def age?
+      @counter.call(:age?)
+      true
+    end
+    memoize 'age?'
+
     def sleep(hours = 8)
       @counter.call(:sleep)
       hours
@@ -272,6 +278,13 @@ class MemoistTest < Minitest::Test
     @person.unmemoize_all
   end
 
+  def test_memoization_when_memoize_is_called_with_punctuated_string
+    assert_equal true, @person.age?
+
+    @person.memoize_all
+    @person.unmemoize_all
+  end
+
   def test_memoization_flush_with_punctuation
     assert_equal true, @person.name?
     @person.flush_cache(:name?)
@@ -344,11 +357,11 @@ class MemoistTest < Minitest::Test
   end
 
   def test_all_memoized_structs
-    # Person             memoize :age, :is_developer?, :memoize_protected_test, :name, :name?, :sleep, :update, :update_attributes
+    # Person             memoize :age, :age?, :is_developer?, :memoize_protected_test, :name, :name?, :sleep, :update, :update_attributes
     # Student < Person   memoize :name, :identifier => :student
     # Teacher < Person   memoize :seniority
 
-    expected = %w[age is_developer? memoize_protected_test name name? sleep update update_attributes]
+    expected = %w[age age? is_developer? memoize_protected_test name name? sleep update update_attributes]
     structs = Person.all_memoized_structs
     assert_equal expected, structs.collect(&:memoized_method).collect(&:to_s).sort
     assert_equal '@_memoized_name', structs.detect { |s| s.memoized_method == :name }.ivar


### PR DESCRIPTION
There was a recent change [1] made to how punctuation is escaped to address
an issue introduced by a proposal in Ruby 2.7 (which is to change the
behaviour of `Symbol#to_s` so that it returns a frozen string) [2].

This ended up breaking support for calling the `memoize` method with a
punctuated string [3], e.g.

```ruby
class Dog
  extend Memoist

  def woof?
    true
  end

  memoize 'woof?'
end
```

I have added an additional test which should prevent further regressions
from being introduced.

[1] a893ce6
[2] https://bugs.ruby-lang.org/issues/16150
[3] https://github.com/matthewrudy/memoist/issues/85