### PR TITLE
Update readme to mention potential memory bloat [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ class AccurateClock < Clock
 end
 ```
 
+Ruby will not garbage colllect memoized class methods, which can lead to memory bloat if the memoized class methods accepts arguments.
 
 Reload
 ------


### PR DESCRIPTION
Closes #47 

Updates the readme to mention memoized class methods can lead to memory bloat.