### PR TITLE
Use ruby2_keywords for Ruby 3.0.0 compatibility

### DIFF
--- a/lib/memoist.rb
+++ b/lib/memoist.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'memoist/version'
+require 'ruby2_keywords'
 
 module Memoist
   def self.extended(extender)
@@ -203,7 +204,7 @@ module Memoist
           # end
 
           module_eval <<-EOS, __FILE__, __LINE__ + 1
-            def #{method_name}(*args)
+            ruby2_keywords def #{method_name}(*args)
               reload = Memoist.extract_reload!(method(#{unmemoized_method.inspect}), args)
 
               skip_cache = reload || !(instance_variable_defined?(#{memoized_ivar.inspect}) && #{memoized_ivar} && #{memoized_ivar}.has_key?(args))

--- a/memoist.gemspec
+++ b/memoist.gemspec
@@ -37,10 +37,15 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'minitest', '~> 5.10'
+
   if RUBY_VERSION < '1.9.3'
     spec.add_development_dependency 'rake', '~> 10.4'
   else
     spec.add_development_dependency 'rake'
   end
-  spec.add_development_dependency 'minitest', '~> 5.10'
+
+  if RUBY_VERSION < '3.0.0'
+    spec.add_dependency 'ruby2_keywords'
+  end
 end


### PR DESCRIPTION
This isn't exactly ideal, as a more proper fix would involve checking the `Method#parameters` values for `rest` and `kwargs` arguments, but the basic idea is this patch gets Memoist working with Ruby 3.0.0's more distinct separation of argument types by reverting back to Ruby 2-style memoized methods. It would be much better to support this new style of arguments, but in the meantime, this will work with the caveat that only Ruby 2-style methods can be memoized using Ruby 3+, and even then only temporarily, as the `ruby2_keywords` method is only a temporary fix according to their docs. (See https://ruby-doc.org/core-3.0.0/Module.html#method-i-ruby2_keywords.)