### PR TITLE
Add ruby 3 compatibility.

### DIFF
--- a/test/memoist/args_test.rb
+++ b/test/memoist/args_test.rb
@@ -1,0 +1,39 @@
+require 'pry-rails'
+require 'test_helper'
+require_relative '../support/named_args_helper'
+
+class MemoistNamedArgsTest < Minitest::Test
+  def test_named_args_class_initialization
+    instance1 = ::NamedArgsHelper.new(a1: 11)
+    instance2 = ::NamedArgsHelper.new(a1: 11)
+
+    refute_same instance1, instance2
+  end
+
+  def test_memoized_object_is_properly_caching_with_named_args
+    instance = ::NamedArgsHelper.new(a1: 11)
+    result1 = instance.calc_with_named_args(a2: 12, a3: 13)
+    _result2 = instance.calc_with_named_args(a2: 13, a3: 13)
+    result3 = instance.calc_with_named_args(a2: 12, a3: 13)
+
+    assert_same result1, result3
+  end
+
+  def test_memoized_object_is_properly_caching_with_positioned_args
+    instance = ::NamedArgsHelper.new(a1: 11)
+    result1 = instance.calc_with_positioned_args(12, 13)
+    _result2 = instance.calc_with_positioned_args(13, 13)
+    result3 = instance.calc_with_positioned_args(12, 13)
+
+    assert_same result1, result3
+  end
+
+  def test_memoized_object_is_properly_caching_with_mixed_args
+    instance = ::NamedArgsHelper.new(a1: 11)
+    result1 = instance.calc_with_mixed_args(12, a3: 13)
+    _result2 = instance.calc_with_mixed_args(13, a3: 13)
+    result3 = instance.calc_with_mixed_args(12, a3: 13)
+
+    assert_same result1, result3
+  end
+end

--- a/test/support/named_args_helper.rb
+++ b/test/support/named_args_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'memoist'
+
+class NamedArgsHelper
+  extend Memoist
+
+  def initialize(a1:)
+    @a1 = a1
+  end
+
+  def calc_with_named_args(a2:, a3: nil)
+    create_object(a1: a1, a2: a2, a3: a3)
+  end
+  memoize :calc_with_named_args
+
+  def calc_with_positioned_args(a2, a3 = nil)
+    create_object(a1: a1, a2: a2, a3: a3)
+  end
+  memoize :calc_with_positioned_args
+
+  def calc_with_mixed_args(a2, a3: nil)
+    create_object(a1: a1, a2: a2, a3: a3)
+  end
+  memoize :calc_with_mixed_args
+
+  private
+
+  attr_reader :a1
+
+  def create_object(**named_args)
+    OpenStruct.new(**named_args)
+  end
+end


### PR DESCRIPTION
After the release of Ruby 3, the division into positional and named arguments has changed.
Because of this, memoization of some functions became impossible.

This pull request addresses the compatibility issue and also adds coverage for some cases.